### PR TITLE
Delete _original from an Edited Message

### DIFF
--- a/src/network-api.ts
+++ b/src/network-api.ts
@@ -922,6 +922,7 @@ export default class DiscordNetworkAPI {
 
         const message = mapMessage(mapped, this.currentUser?.id)
         if (!message) return
+        delete message._original
 
         this.eventCallback([{
           type: ServerEventType.STATE_SYNC,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,7 +1093,7 @@ __metadata:
   peerDependencies:
     eslint: ">=7"
     typescript: ">=4"
-  checksum: 61508a7905945bc62c20308c9c9f884b0e80307f2e6dca2809533d85da048e7f05bdb19defe991e007f14213ce7a85c225ad206bbfa792e17fe938fb73ff45b2
+  checksum: d21566145f4e49f1f82d1f7f058f7354af305bd684dddabacd03d217da58d232974e5fe31637621c920bfc9a6b31ad8af8505f6b671e2dd5dc4ad6ccca56fe61
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Was getting this error on Discord when editing a message:

```
{
  platformName: 'discord',
  accountID: 'discord_3a8c9cd84528788f1db56f95858dfecc',
  methodName: 'subscribeToEvents'
} invalid StateSyncEvent[0].entries for mutationType = 'update': should not have '_original' field {
  _original: '{"id":"1021903376507740351","type":0,"content":"test5?","channel_id":"911273978767757312","author":{"avatar":"17271c600662f3b4cf1c60df5ba6c0ed","avatar_decoration":null,"discriminator":"1192","id":"693620266647158805","public_flags":0,"username":"thot"},"attachments":[],"embeds":[],"mentions":[],"mention_roles":[],"pinned":false,"mention_everyone":false,"tts":false,"timestamp":"2022-09-20T21:59:11.006000+00:00","edited_timestamp":"2022-09-20T22:24:51.823466+00:00","flags":0,"components":[]}',
  id: '1021903376507740351',
  linkedMessageID: undefined,
  threadID: '911273978767757312',
  text: 'test5?',
  senderID: '693620266647158805',
  isSender: true,
  timestamp: 2022-09-20T21:59:11.006Z,
  editedTimestamp: 2022-09-20T22:24:51.823Z,
  tweets: [],
  links: [],
  attachments: []
}
```

Deleted `_original` from the message when we're editing so that it doesn't change the OG message.
